### PR TITLE
Remove CodeQL Configuration

### DIFF
--- a/.github/other-configurations/codeql-config.yml
+++ b/.github/other-configurations/codeql-config.yml
@@ -1,3 +1,0 @@
-query-filters:
-  - exclude:
-      id: actions/unpinned-tag

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -125,6 +125,5 @@ jobs:
         with:
           languages: actions
           queries: security-and-quality
-          config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.10


### PR DESCRIPTION
# Pull Request

## Description

This pull request simplifies the CodeQL configuration by removing a custom query filter and its associated configuration file reference in the workflow.

CodeQL configuration changes:

* [`.github/other-configurations/codeql-config.yml`](diffhunk://#diff-687a0af9316072cbdab79cdb046aac181231f8b5f3b5502bc796a9d949ce65beL1-L3): Removed the `actions/unpinned-tag` query filter from the CodeQL configuration.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L128): Removed the reference to the custom CodeQL configuration file, streamlining the workflow configuration.