### PR TITLE
Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,8 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration to modify the scheduling method for dependency updates.

* **Dependabot scheduling adjustment**:
  * [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L10-R11): Changed the update schedule from a daily interval at 01:00 London time to a cron-based schedule set to "30 7 * * *".