### PR TITLE
Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    commit-message:
+      prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,19 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
-    directories:
-      - "/"
-    commit-message:
-      prefix: "deps(github-actions)"
+    directory: "/"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to streamline GitHub Actions dependency updates and improve scheduling flexibility.

### Updates to Dependabot configuration:

* Consolidated the `directories` field into a single `directory` field for simplicity. (`[.github/dependabot.ymlL5-R19](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R19)`)
* Added a `timezone` field set to `Europe/London` to specify the time zone for the cron schedule. (`[.github/dependabot.ymlL5-R19](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R19)`)
* Enhanced the `groups` configuration for `github-actions` updates by introducing an `applies-to` field set to `version-updates`, and added `exclude-patterns` to exclude updates matching the pattern `super-linter/*`. (`[.github/dependabot.ymlL5-R19](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R19)`)