### PR TITLE
Update Dependabot Configuration for Reusable Workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "super-linter/*"
+          - "super-linter/super-linter"
           - "JackPlowman/reusable-workflows/*"
         update-types:
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
           - "*"
         exclude-patterns:
           - "super-linter/*"
+          - "JackPlowman/reusable-workflows/*"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` file to refine the dependency update rules by modifying the `exclude-patterns` section.

Dependency update rules:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L19-R20): Adjusted the `exclude-patterns` to exclude updates for `super-linter/super-linter` instead of the broader `super-linter/*`, and added a new exclusion for `JackPlowman/reusable-workflows/*`.