### PR TITLE
Change Jobs to Common Code Checks

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -33,79 +33,15 @@ jobs:
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
 
-  check-markdown-links:
-    name: Check Markdown links
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@c6d4525e9f50b27a0e78fc42b537141058d034ef # v1.3.1
-        with:
-          github_token: ${{ secrets.GH_TOKEN }}
-          config_file: .github/other-configurations/.linkspector.yml
-          reporter: github-pr-review
-          fail_on_error: true
-          filter_mode: nofilter
-          show_stats: true
-
-  check-justfile-format:
-    name: Check Justfile Format
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Just
-        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
-      - name: Check Justfile Format
-        run: just format-check
-
-  run-zizmor:
-    name: Check GitHub Actions with zizmor
-    runs-on: ubuntu-latest
+  common-code-checks:
+    name: Common Code Checks
     permissions:
+      contents: read
+      pull-requests: read
       security-events: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
-      - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
-      - name: Run zizmor 🌈
-        run: just zizmor-check-sarif
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
-        with:
-          sarif_file: results.sarif
-          category: zizmor
-
-  lefthook-validate:
-    name: Lefthook Validate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
-        with:
-          version: "latest"
-      - name: Run Lefthook Validate
-        run: uvx lefthook validate
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@14445779094fde883fdb9f65946fcae6c25f46c0 # v2025.05.14.01
+    secrets:
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
   run-codeql-analysis:
     name: CodeQL Analysis


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors the GitHub Actions workflow by consolidating multiple individual jobs into a single reusable workflow for common code checks. This change simplifies the workflow configuration and reduces redundancy.

### Workflow Refactoring:
* Removed the `check-markdown-links`, `check-justfile-format`, `run-zizmor`, and `lefthook-validate` jobs, which previously handled specific code checks individually.
* Introduced a new `common-code-checks` job that uses a reusable workflow (`JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml`) to handle these checks collectively.
