### PR TITLE
Set Zizmor persona to auditor

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@8f2eda10bf25fcde227b8912532306822183645e # v2025.06.12.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -40,7 +40,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@8f2eda10bf25fcde227b8912532306822183645e # v2025.06.12.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -52,6 +52,6 @@ jobs:
     strategy:
       matrix:
         language: [actions]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@8f2eda10bf25fcde227b8912532306822183645e # v2025.06.12.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -12,6 +12,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@8f2eda10bf25fcde227b8912532306822183645e # v2025.06.12.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,6 +15,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@8f2eda10bf25fcde227b8912532306822183645e # v2025.06.12.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Justfile
+++ b/Justfile
@@ -44,7 +44,7 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    uvx zizmor . --persona=pedantic
+    uvx zizmor . --persona=auditor
 
 # ------------------------------------------------------------------------------
 # Pinact

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 # https://github.com/evilmartians/lefthook
-min_version: 1.11.13
+min_version: 1.11.14
 colors: true
 
 output:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several workflows and configurations to use newer versions of reusable workflows and tools. The changes ensure compatibility with the latest versions and align with updated standards.

### Workflow Updates:
* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15): Updated reusable workflow version for cleaning caches to `v2025.06.16.01`.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L43-R43): Updated reusable workflow versions for code checks and CodeQL analysis to `v2025.06.16.01`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L43-R43) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L55-R55)
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL15-R15): Updated reusable workflow version for pull request tasks to `v2025.06.16.01`.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L18-R18): Updated reusable workflow version for syncing labels to `v2025.06.16.01`.

### Configuration Updates:
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL47-R47): Changed the `zizmor` persona from `pedantic` to `auditor`, likely reflecting a change in validation criteria.
* [`lefthook.yml`](diffhunk://#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884dL2-R2): Updated the minimum version of Lefthook to `1.11.14`.