### PR TITLE
Force Colour in Code Checks Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -12,6 +12,9 @@ permissions:
   contents: read
   packages: read
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   check-code-quality:
     name: Check Code Quality


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small addition to the `.github/workflows/code-checks.yml` file. The change sets the `FORCE_COLOR` environment variable to `1` under the `permissions:` section to ensure colored output in workflows.